### PR TITLE
Add text evaluation API server

### DIFF
--- a/text-eval-api/index.js
+++ b/text-eval-api/index.js
@@ -1,0 +1,57 @@
+require('dotenv').config();
+const express = require('express');
+const fetch = require('node-fetch');
+
+const app = express();
+app.use(express.json());
+
+// CORS
+app.use((req, res, next) => {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,PUT,DELETE,OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  if (req.method === 'OPTIONS') return res.sendStatus(200);
+  next();
+});
+
+const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
+
+// Helper to build prompt
+const buildPrompt = (text, criteria) => {
+  const judge = `システムトーン: analytic_brief\n評価プロファイル:\n  - logic\n  - factuality\n  - creativity\n  - empathy\n  - brevity\n総合点を0〜10で出し、各軸にコメントをつける。`;
+  const fact = `この文章の事実性を検証し、根拠を提示する。\n根拠が無い場合は「要出典」と答える。`;
+  const criteriaList = criteria.join(', ');
+  return `${judge}\n${fact}\n評価基準: ${criteriaList}\n\n評価対象:\n${text}\n\n以下のJSON形式で回答してください。\n{\n  \"summary\": \"string\",\n  \"scores\": [{ \"criterion\": \"logic\", \"score\": 0, \"comment\": \"\" }]
+}`;
+};
+
+app.post('/text/evaluate', async (req, res) => {
+  const { text, criteria = ['logic', 'factuality', 'creativity'], model = 'gemini-2.5-pro' } = req.body;
+  if (!text) return res.status(400).json({ error: 'text required' });
+
+  const prompt = buildPrompt(text, criteria);
+  const payload = { model, prompt, temperature: 0.3, max_tokens: 500 };
+
+  try {
+    const response = await fetch('https://api.gemini.google.com/v1/text/generate', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${GEMINI_API_KEY}`,
+      },
+      body: JSON.stringify(payload),
+    });
+    const data = await response.json();
+    const textResp = data.text || data.choices?.[0]?.text || '';
+    const match = textResp.match(/\{[\s\S]*\}/);
+    if (!match) throw new Error('Invalid Gemini response');
+    const result = JSON.parse(match[0]);
+    res.json(result);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to evaluate text' });
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/text-eval-api/package.json
+++ b/text-eval-api/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "text-eval-api",
+  "version": "1.0.0",
+  "description": "Simple API for text evaluation using Gemini",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "type": "commonjs",
+  "dependencies": {
+    "dotenv": "^17.0.0",
+    "express": "^5.1.0",
+    "node-fetch": "^2.7.0"
+  }
+}


### PR DESCRIPTION
## Summary
- create `text-eval-api` folder with Express server for `/text/evaluate`
- allow CORS, build prompt for judging and fact-checking
- call Gemini API and return structured JSON

## Testing
- `node -v`
- `npm start` (server can be started)


------
https://chatgpt.com/codex/tasks/task_e_685fce796de08330a2318830fa6eaf7b