### PR TITLE
Add dummy /text/evaluate endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,5 +44,26 @@ app.post('/generate', async (req, res) => {
   }
 });
 
+// Dummy evaluation endpoint
+app.post('/text/evaluate', (req, res) => {
+  // Log incoming JSON
+  console.log('Received /text/evaluate:', req.body);
+
+  const dummyResponse = {
+    id: 'dummy-id',
+    created: Math.floor(Date.now() / 1000),
+    evaluation: {
+      summary: 'これはダミーの評価結果です。',
+      scores: [
+        { criterion: 'logic', score: 0.9, comment: '論理的です' },
+        { criterion: 'factuality', score: 0.8, comment: 'おおむね正確です' }
+      ]
+    }
+  };
+
+  res.setHeader('Content-Type', 'application/json');
+  res.json(dummyResponse);
+});
+
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => console.log(`Server running on port ${PORT}`));


### PR DESCRIPTION
## Summary
- add `/text/evaluate` POST route
- log request body and return static JSON result

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685fd815aa508330830917a7604479f9