### PR TITLE
Switch to generative language API

### DIFF
--- a/docs/agent.md
+++ b/docs/agent.md
@@ -26,15 +26,15 @@ This agent integrates OpenAI GPT-4.1 (primary generator) and Gemini (auxiliary e
 
 ## Gemini API Usage
 **Endpoint:**
-POST https://api.gemini.google.com/v1/text/generate
-
+POST https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent
 **Request Structure:**
 ```json
 {
-  "model": "gemini-2.5-pro",
-  "prompt": "<evaluation_prompt>",
-  "max_tokens": 500,
-  "temperature": 0.3
+  "contents": [{ "parts": [{ "text": "<evaluation_prompt>" }] }],
+  "generationConfig": {
+    "maxOutputTokens": 500,
+    "temperature": 0.3
+  }
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -21,12 +21,17 @@ app.post('/generate', async (req, res) => {
     return res.status(400).json({ error: 'prompt required' });
   }
 
-  const body = { prompt };
-  if (max_tokens !== undefined) body.max_tokens = max_tokens;
-  if (temperature !== undefined) body.temperature = temperature;
+  const body = {
+    contents: [{ parts: [{ text: prompt }] }]
+  };
+  if (max_tokens !== undefined || temperature !== undefined) {
+    body.generationConfig = {};
+    if (max_tokens !== undefined) body.generationConfig.maxOutputTokens = max_tokens;
+    if (temperature !== undefined) body.generationConfig.temperature = temperature;
+  }
 
   try {
-    const response = await fetch('https://api.gemini.google.com/v1/text/generate', {
+    const response = await fetch('https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -36,7 +41,7 @@ app.post('/generate', async (req, res) => {
     });
 
     const data = await response.json();
-    const text = data.text || data.choices?.[0]?.text || '';
+    const text = data.candidates?.[0]?.content?.parts?.[0]?.text || '';
     return res.json({ text });
   } catch (err) {
     console.error(err);

--- a/src/main-app/server.js
+++ b/src/main-app/server.js
@@ -58,11 +58,10 @@ app.post('/api/chat', async (req, res) => {
     try {
       const judgePrompt = loadPrompt('judge_prompt.md');
       const geminiPayload = {
-        model: 'gemini-2.5-pro',
-        prompt: `${judgePrompt}\n${gptResponse}`,
-        temperature: 0.3,
+        contents: [{ parts: [{ text: `${judgePrompt}\n${gptResponse}` }] }],
+        generationConfig: { temperature: 0.3 },
       };
-      const geminiRes = await fetch('https://api.gemini.google.com/v1/text/generate', {
+      const geminiRes = await fetch('https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -71,7 +70,7 @@ app.post('/api/chat', async (req, res) => {
         body: JSON.stringify(geminiPayload),
       });
       const data = await geminiRes.json();
-      evaluation = data.choices?.[0]?.text?.trim() || null;
+      evaluation = data.candidates?.[0]?.content?.parts?.[0]?.text?.trim() || null;
     } catch (err) {
       evaluation = `Gemini API error: ${err.message}`;
     }

--- a/text-eval-api/index.js
+++ b/text-eval-api/index.js
@@ -30,10 +30,13 @@ app.post('/text/evaluate', async (req, res) => {
   if (!text) return res.status(400).json({ error: 'text required' });
 
   const prompt = buildPrompt(text, criteria);
-  const payload = { model, prompt, temperature: 0.3, max_tokens: 500 };
+  const payload = {
+    contents: [{ parts: [{ text: prompt }] }],
+    generationConfig: { temperature: 0.3, maxOutputTokens: 500 },
+  };
 
   try {
-    const response = await fetch('https://api.gemini.google.com/v1/text/generate', {
+    const response = await fetch('https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -42,7 +45,7 @@ app.post('/text/evaluate', async (req, res) => {
       body: JSON.stringify(payload),
     });
     const data = await response.json();
-    const textResp = data.text || data.choices?.[0]?.text || '';
+    const textResp = data.candidates?.[0]?.content?.parts?.[0]?.text || '';
     const match = textResp.match(/\{[\s\S]*\}/);
     if (!match) throw new Error('Invalid Gemini response');
     const result = JSON.parse(match[0]);


### PR DESCRIPTION
## Summary
- update main server to call generativelanguage.googleapis.com
- update evaluation servers to use the new endpoint
- document new Gemini endpoint and request format

## Testing
- `npm install`
- `node index.js` *(fails: missing dotenv before install)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685fdd5a8e248330b44769eafb002d0a