### PR TITLE
Enable Gemini-based evaluation endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ npm start
 - Gemini APIで外部検証を実施
 - 結果をユーザーに通知・表示
 
+### APIエンドポイント
+ - **POST /generate** : 指定した`prompt`からテキストを生成します。
+ - **POST /text/evaluate** : 文章を指定の観点で評価します。
+
 ---
 
 ## 📖 ドキュメント


### PR DESCRIPTION
## Summary
- implement `/text/evaluate` with real Gemini API calls
- document `/generate` and `/text/evaluate` endpoints

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68606ce195348330bdc373d07c8c6cc8