### PR TITLE
Fix Gemini response handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,13 @@ app.post("/text/evaluate", async (req, res) => {
     const data = await callGemini(prompt, { maxTokens: 500, temperature: 0.3 });
     const rawText = data.candidates?.[0]?.content?.parts?.[0]?.text || "";
     const match = rawText.match(/\{[\s\S]*\}/);
-    if (!match) throw new Error("Invalid Gemini response");
+    if (!match) {
+      console.error("Gemini response parse failed:", rawText);
+      return res.status(500).json({
+        error: "Gemini\u306E\u5fdc\u7b54\u304c\u89e3\u6790\u3067\u304d\u307e\u305b\u3093",
+        raw: rawText
+      });
+    }
     const result = JSON.parse(match[0]);
     res.json(result);
   } catch (err) {

--- a/text-eval-api/index.js
+++ b/text-eval-api/index.js
@@ -46,7 +46,13 @@ app.post('/text/evaluate', async (req, res) => {
     const data = await response.json();
     const textResp = data.candidates?.[0]?.content?.parts?.[0]?.text || '';
     const match = textResp.match(/\{[\s\S]*\}/);
-    if (!match) throw new Error('Invalid Gemini response');
+    if (!match) {
+      console.error('Gemini response parse failed:', textResp);
+      return res.status(500).json({
+        error: 'Gemini\u306E\u5fdc\u7b54\u304c\u89e3\u6790\u3067\u304d\u307e\u305b\u3093',
+        raw: textResp,
+      });
+    }
     const result = JSON.parse(match[0]);
     res.json(result);
   } catch (err) {


### PR DESCRIPTION
## Summary
- improve error handling when Gemini API does not return JSON
- show raw Gemini response so issues can be diagnosed more easily

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68606eda47308330bc514d08b1340be8