### PR TITLE
Fix Gemini text API usage

### DIFF
--- a/server.js
+++ b/server.js
@@ -11,7 +11,6 @@ app.use(express.json());
 
 const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
 const GEMINI_URL = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${GEMINI_API_KEY}`;
-const GEMINI_TEXT_URL = `https://generativelanguage.googleapis.com/v1beta2/models/gemini-pro:generateText?key=${GEMINI_API_KEY}`;
 
 function loadPrompt(filename) {
   const file = path.join(__dirname, 'prompts', filename);
@@ -63,8 +62,11 @@ app.post('/text/evaluate', async (req, res) => {
   const list = Array.isArray(criteria) && criteria.length ? criteria.join(', ') : '総合';
   const prompt = `以下の文章を次の評価基準で10点満点で採点し、JSON形式で回答してください。\n評価基準: ${list}\n文章:\n${text}`;
   try {
-    const payload = { prompt: { text: prompt }, temperature: 0.3 };
-    const resp = await fetch(GEMINI_TEXT_URL, {
+    const payload = {
+      contents: [{ parts: [{ text: prompt }] }],
+      generationConfig: { temperature: 0.3 }
+    };
+    const resp = await fetch(GEMINI_URL, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload)


### PR DESCRIPTION
## Summary
- remove deprecated `generateText` endpoint
- use `generateContent` for text evaluation

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6860c64f2c2c8330b406821fdba65381