### PR TITLE
Improve logging and error checks

### DIFF
--- a/dist/factcheck-system/factcheck.js
+++ b/dist/factcheck-system/factcheck.js
@@ -33,7 +33,7 @@ async function verifyClaim(claim) {
     const apiKey = process.env.GEMINI_API_KEY;
     if (!apiKey)
         throw new Error('GEMINI_API_KEY is not set');
-    const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-pro-latest:generateContent?key=${apiKey}`;
+    const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${apiKey}`;
     const prompt = `以下の主張が正しいか調べ、JSONで回答してください。公式サイトや複数ソースを優先して検索し、根拠となるURLと抜粋を示してください。\n主張: ${claim.subject} ${claim.predicate}${claim.object ? ' ' + claim.object : ''}`;
     const body = {
         contents: [{ role: 'user', parts: [{ text: prompt }] }]
@@ -46,6 +46,10 @@ async function verifyClaim(claim) {
     if (!res.ok)
         throw new Error(`Gemini API error: ${res.status}`);
     const data = await res.json();
+    if (data.error) {
+        console.error('Gemini API error:', JSON.stringify(data));
+        throw new Error('Gemini API error');
+    }
     const text = (_j = (_f = (_e = (_d = (_c = (_b = (_a = data.candidates) === null || _a === void 0 ? void 0 : _a[0]) === null || _b === void 0 ? void 0 : _b.content) === null || _c === void 0 ? void 0 : _c.parts) === null || _d === void 0 ? void 0 : _d[0]) === null || _e === void 0 ? void 0 : _e.text) !== null && _f !== void 0 ? _f : (_h = (_g = data.candidates) === null || _g === void 0 ? void 0 : _g[0]) === null || _h === void 0 ? void 0 : _h.text) !== null && _j !== void 0 ? _j : '';
     const m = text.match(/\{[\s\S]*\}/);
     if (!m)

--- a/src/factcheck-system/factcheck.ts
+++ b/src/factcheck-system/factcheck.ts
@@ -26,7 +26,7 @@ export async function verifyClaim(claim: Claim): Promise<Verification> {
   const apiKey = process.env.GEMINI_API_KEY;
   if (!apiKey) throw new Error('GEMINI_API_KEY is not set');
 
-  const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-pro-latest:generateContent?key=${apiKey}`;
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${apiKey}`;
 
   const prompt = `以下の主張が正しいか調べ、JSONで回答してください。公式サイトや複数ソースを優先して検索し、根拠となるURLと抜粋を示してください。\n主張: ${claim.subject} ${claim.predicate}${claim.object ? ' ' + claim.object : ''}`;
 
@@ -42,6 +42,10 @@ export async function verifyClaim(claim: Claim): Promise<Verification> {
 
   if (!res.ok) throw new Error(`Gemini API error: ${res.status}`);
   const data = await res.json();
+  if ((data as any).error) {
+    console.error('Gemini API error:', JSON.stringify(data));
+    throw new Error('Gemini API error');
+  }
   const text =
     data.candidates?.[0]?.content?.parts?.[0]?.text ??
     data.candidates?.[0]?.text ??


### PR DESCRIPTION
## Summary
- add request logging middleware for chat and text evaluation
- check Gemini API error responses and log details
- unify gemini model names to gemini-2.5-flash

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860ce69971483309b20db0aba4ceabc