### PR TITLE
Implement Gemini two-step evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ npm start
 ### APIエンドポイント
  - **POST /api/chat** : 三人格で応答を生成します。
  - **POST /factcheck** : 文章から主張を抽出し、Geminiで検証します。
+ - **POST /text/evaluate** : Geminiを利用して文章を採点し、必要に応じて訂正文も返します。
+
+`/text/evaluate` はまず correctness を採点し、点数が低い場合のみ訂正文を生成する二段階方式です。
 
 ---
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -43,32 +43,25 @@ components:
             type: string
       required:
         - text
-    Score:
-      type: object
-      properties:
-        criterion:
-          type: string
-          description: Criterion name
-        score:
-          type: number
-          description: Numeric score (0-10 scale)
-        comment:
-          type: string
-          nullable: true
-          description: Additional comments
-      required:
-        - criterion
-        - score
     EvaluateTextResponse:
       type: object
       properties:
-        summary:
+        correctness:
+          type: number
+          description: Correctness score (0-10)
+        sources:
+          type: array
+          description: List of reference URLs
+          items:
+            type: string
+        correction:
           type: string
           nullable: true
-          description: High-level summary
-        scores:
-          type: array
-          items:
-            $ref: '#/components/schemas/Score'
+          description: Corrected text
+        explanation:
+          type: string
+          nullable: true
+          description: Why the correction was needed
       required:
-        - scores
+        - correctness
+        - sources


### PR DESCRIPTION
## Summary
- add Gemini scoring/fix constants and helper functions
- revise `/text/evaluate` to run score then correction when needed
- document new response in OpenAPI spec
- mention evaluation endpoint in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860d993583c8330ba475d522a793054